### PR TITLE
Not able to navigate to Home screen after clicking the 'Checkout' button. #63

### DIFF
--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/ShopSmartNavBar.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/ShopSmartNavBar.kt
@@ -55,12 +55,13 @@ fun ShopSmartNavBar(navController: NavHostController) {
                 selected = currentDestination?.route == item.title,
                 onClick = {
                     navController.navigate(item.title){
+                        if(item.title!="Home"){
                         popUpTo(navController.graph.startDestinationId) {
                             saveState = true
                         }
+                        }
                         launchSingleTop = true
                         restoreState = true
-
                     }
                 },
                 icon = {

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/ShopSmartNavBar.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/ShopSmartNavBar.kt
@@ -54,15 +54,10 @@ fun ShopSmartNavBar(navController: NavHostController) {
             NavigationBarItem(
                 selected = currentDestination?.route == item.title,
                 onClick = {
-                    navController.navigate(item.title){
-                        if(item.title!="Home"){
-                        popUpTo(navController.graph.startDestinationId) {
-                            saveState = true
+                        navController.navigate(item.title) {
+                            launchSingleTop = true
+                            restoreState = true
                         }
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
                 },
                 icon = {
                     Icon(


### PR DESCRIPTION
I removed the line popUpTo(navController.graph.startDestinationId) {
                                saveState = true
                            } to avoid unwanted behavior when navigating to multiple different screens.

--popUpTo() is beneficial in certain scenarios, particularly:

When navigating to a new feature: If you navigate to a new section of your app (like an authentication flow), you might want to clear the previous screens to prevent back navigation to them.
Preventing memory leaks: If you have screens that hold onto resources or listeners and you want to ensure they're cleared from memory, popUpTo() can help with that. 