### PR TITLE
Checkout button appearance/Myorder Screen Fixed

### DIFF
--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/Navigation.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/Navigation.kt
@@ -35,8 +35,9 @@ fun Navigation(viewModel: ShoppingListViewModel, navController: NavHostControlle
             composable("Profile") {
                 Profile(navController = navController)
             }
-            composable("MyOrders") {
-                MyOrders(navController = navController)
+            composable("MyOrders?selectedItems={selectedItems}") { backStackEntry ->
+                val selectedItemsJson = backStackEntry.arguments?.getString("selectedItems")
+                MyOrders(navController = navController, selectedItemsJson = selectedItemsJson ?: "[]")
             }
             composable("Help") {
                 HelpS(navController = navController)

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/HomeScreen.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/HomeScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
+import com.google.gson.Gson
 import com.yuvrajsinghgmx.shopsmart.R
 import com.yuvrajsinghgmx.shopsmart.datastore.Poduct
 import com.yuvrajsinghgmx.shopsmart.datastore.saveItems
@@ -201,7 +202,59 @@ fun HomeScreen(viewModel: ShoppingListViewModel = hiltViewModel(), navController
                 )
             }
         },
-        ) {innerPadding->
+
+        floatingActionButton = {
+            val subtotal = selectedItems.sumOf { it.amount }
+            val deliveryFee = 0
+            val discount = 0
+            val total = subtotal + deliveryFee - discount
+            if (selectedItems.isNotEmpty()) {
+                FloatingActionButton(
+                    onClick = {
+                        val selectedItemsJson = Gson().toJson(selectedItems)
+                        navController.navigate("MyOrders?selectedItems=$selectedItemsJson")
+                    }
+                ) {
+                    Column(
+                        modifier = Modifier.padding(5.dp).width(150.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Text(
+                                "Total:"
+                            )
+
+                            Text(
+                                "₹${total}",
+                            )
+                        }
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Text("Checkout", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+                        }
+
+                    }
+                }
+            } else {
+                FloatingActionButton(
+                    onClick = { showDialog = true },
+                    modifier = Modifier.padding(5.dp, 0.dp)
+                ) {
+                    Icon(
+                        Icons.Default.Add,
+                        contentDescription = "Add Item",
+                    )
+                }
+            }
+        }
+
+
+    ) {innerPadding->
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -250,14 +303,6 @@ fun HomeScreen(viewModel: ShoppingListViewModel = hiltViewModel(), navController
                             "Add items using the  button below.",
                             style = TextStyle(fontSize = 16.sp, color = Color.Gray)
                         )
-                    }
-                    FloatingActionButton(
-                        onClick = { showDialog = true },
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .fillMaxWidth().background(Color.White, RectangleShape)
-                    ) {
-                        Text(text = "Add Items")
                     }
                 }
             } else
@@ -342,54 +387,6 @@ fun HomeScreen(viewModel: ShoppingListViewModel = hiltViewModel(), navController
                                     )
                                 }
                             }
-                        }
-                    }
-                }
-
-                Column {
-                    val subtotal = items.value.sumOf { it.amount }
-                    val deliveryFee = 0
-                    val discount = 0
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        val total = subtotal + deliveryFee - discount
-                        Text(
-                            "Total: ₹${total}",
-                            style = TextStyle(
-                                fontSize = 20.sp,
-                                fontWeight = FontWeight.Medium,
-                            )
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Button(
-                            onClick = {
-                                saveOrdersToSharedPreferences(context, items.value)
-                                navController.navigate("MyOrders")
-                            },
-                            modifier = Modifier
-                                .height(56.dp)
-                                .weight(1f)
-                            ,
-                            shape = RoundedCornerShape(10.dp),
-                            colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.primarybg))
-                        ) {
-                            Text("Checkout", color = Color.White, fontSize = 18.sp)
-                        }
-                        FloatingActionButton(
-                            onClick = { showDialog = true },
-                            modifier = Modifier.padding(5.dp,0.dp)
-                        ) {
-                            Icon(
-                                Icons.Default.Add,
-                                contentDescription = "Add Item",
-                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/MyOrders.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/MyOrders.kt
@@ -19,21 +19,28 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.yuvrajsinghgmx.shopsmart.utils.SharedPrefsHelper
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyOrders(navController: NavController) {
+fun MyOrders(navController: NavController, selectedItemsJson: String) {
     val context = LocalContext.current
     var orders by remember { mutableStateOf(listOf<Product>()) }
     val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) {
-        loadOrders(context) { loadedOrders ->
-            orders = loadedOrders
-        }
+//    LaunchedEffect(Unit) {
+//        loadOrders(context) { loadedOrders ->
+//            orders = loadedOrders
+//        }
+//    }
+
+    LaunchedEffect(selectedItemsJson) {
+        orders = Gson().fromJson(selectedItemsJson, object : TypeToken<List<Product>>() {}.type)
     }
+
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
Fixed the appearance of the checkout button for a better user experience and a cleaner UI on the Home Screen.
![Screenshot 2024-10-12 013029](https://github.com/user-attachments/assets/0faec70a-0715-4c2a-b2dc-40b36e434fde)
The checkout button can be added to the top app bar's navigation buttons in the future if needed.

I have made the necessary changes to the MyOrder Screen so that it now only displays the selected items for checkout and provides a final preview.
![Screenshot 2024-10-12 013048](https://github.com/user-attachments/assets/7629c60f-1a3d-47f3-8148-d7183106a485)



