### PR TITLE
 added the UI of "Continue with Email"  + fixed text style

### DIFF
--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/Navigation.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/Navigation.kt
@@ -46,11 +46,16 @@ fun Navigation(viewModel: ShoppingListViewModel, navController: NavHostControlle
 
             composable("emailSignUpScreen") {
                 EmailSignUpScreen(
-//                    onEmailSignUpComplete = {
-//                        navController.navigate("Home") {
-//                            popUpTo("signUpScreen") { inclusive = true }
-//                        }
-//                    }
+                    onSignUpComplete = {
+                        navController.navigate("Home") {
+                            popUpTo("signUpScreen") { inclusive = true }
+                        }
+                    },
+                    onBackButtonClicked = {
+                        navController.navigate("signUpScreen"){
+                            popUpTo("signUpScreen") { inclusive = true }
+                        }
+                    }
                 )
             }
 

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/EmailSignUpScreen.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/EmailSignUpScreen.kt
@@ -1,15 +1,266 @@
 package com.yuvrajsinghgmx.shopsmart.screens
 
+import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yuvrajsinghgmx.shopsmart.R
+import com.yuvrajsinghgmx.shopsmart.ui.theme.dark
 
 @Composable
-fun EmailSignUpScreen(){
+fun EmailSignUpScreen(onSignUpComplete: () -> Unit, onBackButtonClicked:()->Unit) {
+    val context = LocalContext.current
+    var fullName by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
 
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 16.dp, end = 16.dp)
+    ) {
+        Icon(
+            modifier = Modifier.clickable {
+                onBackButtonClicked()
+            }
+                .padding(top = 30.dp),
+            imageVector = Icons.Filled.ArrowBack,
+            contentDescription = "Back",
+        )
+        
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight()
+                .padding(top = 25.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        )
+        {
+
+            Image(
+                painter = painterResource(R.drawable.logo1),
+                contentDescription = "Logo"
+            )
+
+            Spacer(modifier = Modifier.height(50.dp))
+
+            Text(
+                text = "Continue to ShopSmart \n with your Email",
+                fontSize = 25.sp,
+                fontFamily = FontFamily(Font(R.font.lexend_semibold)),
+                textAlign = TextAlign.Center,
+                color = dark
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 20.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+
+                OutlinedTextField(
+                    value = fullName,
+                    onValueChange = {
+                        fullName = it
+                    },
+                    label = { Text("Full Name") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = {
+                        email = it
+                    },
+                    label = { Text("Email") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                OutlinedButton(
+                    onClick = {
+                        //handle onClickListener
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(45.dp),
+                    shape = RoundedCornerShape(10.dp),
+                    colors = ButtonDefaults.buttonColors(Color(0xFF007AFF))
+                ) {
+                    Text(
+                        text = "Continue",
+                        fontFamily = FontFamily(Font(R.font.lexend_medium)),
+                        fontSize = 15.sp,
+                        color = Color.White
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 20.dp, end = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    HorizontalDivider(
+                        color = Color(0x9A888888),
+                        thickness = 0.6.dp,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    Text(
+                        text = "OR",
+                        fontFamily = FontFamily(Font(R.font.lexend_regular)),
+                        color = Color(0xFF888888),
+                        modifier = Modifier.padding(start = 10.dp, end = 10.dp)
+                    )
+
+                    HorizontalDivider(
+                        color = Color(0x9A888888),
+                        thickness = 0.6.dp,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                OutlinedButton(
+                    onClick = {
+                        onSignUpComplete()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(45.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    elevation = ButtonDefaults.buttonElevation(3.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.White)
+                ) {
+                    Row {
+                        Image(
+                            painter = painterResource(id = R.drawable.google),
+                            contentDescription = "Google Logo",
+                            modifier = Modifier.size(24.dp)
+                        )
+
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        Text(
+                            text = "Continue with Google",
+                            fontSize = 15.sp,
+                            color = Color.Black,
+                            fontFamily = FontFamily(Font(R.font.lexend_medium))
+                        )
+                    }
+                }
+
+                Column(
+                    verticalArrangement = Arrangement.Bottom,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(bottom = 30.dp)
+                ) {
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+
+                        Icon(
+                            imageVector = Icons.Filled.Info,
+                            contentDescription = "Info Icon",
+                            tint = Color.Cyan,
+                            modifier = Modifier
+                                .size(24.dp)
+                                .padding(end = 3.dp)
+                        )
+
+                        Text(
+                            text = "By continuing, you agree to our",
+                            fontFamily = FontFamily(Font(R.font.lexend_regular)),
+                            color = Color(0xFF888888),
+                        )
+
+                        Text(
+                            text = "Terms of Use",
+                            fontFamily = FontFamily(Font(R.font.lexend_regular)),
+                            color = Color.Blue,
+                            fontSize = 15.sp,
+                            modifier = Modifier
+                                .clickable {
+                                    Toast
+                                        .makeText(
+                                            context,
+                                            "Terms of Use Clicked",
+                                            Toast.LENGTH_SHORT
+                                        )
+                                        .show()
+                                }
+                                .padding(start = 5.dp)
+                                .fillMaxWidth()
+
+                        )
+                    }
+                }
+
+
+            }
+        }
+    }
 }
 
-@Preview(showBackground = true, showSystemUi = true)
+@Preview(showBackground = true, showSystemUi = true, device = "spec:width=411dp,height=891dp")
 @Composable
-fun SingUpScreenPreview(){
-    EmailSignUpScreen()
+fun SingUpScreenPreview() {
+  EmailSignUpScreen(onSignUpComplete = {}, onBackButtonClicked = {})
 }

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/EmailSignUpScreen.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/EmailSignUpScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Info
@@ -35,9 +37,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -50,6 +56,17 @@ fun EmailSignUpScreen(onSignUpComplete: () -> Unit, onBackButtonClicked:()->Unit
     val context = LocalContext.current
     var fullName by remember { mutableStateOf("") }
     var email by remember { mutableStateOf("") }
+
+    val annotatedString = buildAnnotatedString {
+        append("By continuing, you agree to our ")
+
+        // Add "Terms of Use" as clickable text
+        pushStringAnnotation(tag = "terms", annotation = "terms_of_use")
+        withStyle(style = SpanStyle(color = Color.Blue, fontSize = 15.sp)) {
+            append("Terms of Use")
+        }
+        pop() // End the clickable part
+    }
 
     Box(
         modifier = Modifier
@@ -222,33 +239,26 @@ fun EmailSignUpScreen(onSignUpComplete: () -> Unit, onBackButtonClicked:()->Unit
                             tint = Color.Cyan,
                             modifier = Modifier
                                 .size(24.dp)
-                                .padding(end = 3.dp)
+
                         )
 
-                        Text(
-                            text = "By continuing, you agree to our",
-                            fontFamily = FontFamily(Font(R.font.lexend_regular)),
-                            color = Color(0xFF888888),
-                        )
-
-                        Text(
-                            text = "Terms of Use",
-                            fontFamily = FontFamily(Font(R.font.lexend_regular)),
-                            color = Color.Blue,
-                            fontSize = 15.sp,
+                        ClickableText(
+                            text = annotatedString,
+                            style = TextStyle(
+                                fontFamily = FontFamily(Font(R.font.lexend_regular)),
+                                color = Color(0xFF888888)
+                            ),
                             modifier = Modifier
-                                .clickable {
-                                    Toast
-                                        .makeText(
-                                            context,
-                                            "Terms of Use Clicked",
-                                            Toast.LENGTH_SHORT
-                                        )
-                                        .show()
-                                }
-                                .padding(start = 5.dp)
-                                .fillMaxWidth()
-
+                                .padding(16.dp)
+                                .wrapContentWidth(),
+                            onClick = { offset ->
+                                // Check if the user clicked on the "Terms of Use" part
+                                annotatedString.getStringAnnotations(tag = "terms", start = offset, end = offset)
+                                    .firstOrNull()?.let {
+                                        // Perform the action for "Terms of Use" click
+                                        Toast.makeText(context, "Terms of Use Clicked", Toast.LENGTH_SHORT).show()
+                                    }
+                            }
                         )
                     }
                 }

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/EmailSignUpScreen.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/EmailSignUpScreen.kt
@@ -142,7 +142,7 @@ fun EmailSignUpScreen(onSignUpComplete: () -> Unit, onBackButtonClicked:()->Unit
 
                 OutlinedButton(
                     onClick = {
-                        //handle onClickListener
+                       //click handle
                     },
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/Signup.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/Signup.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.yuvrajsinghgmx.shopsmart.R
 import com.yuvrajsinghgmx.shopsmart.ui.theme.ShopSmartTheme
+import com.yuvrajsinghgmx.shopsmart.ui.theme.dark
+import com.yuvrajsinghgmx.shopsmart.ui.theme.subHeadingColor
 
 @Composable
 fun SignUpScreen(
@@ -60,7 +62,7 @@ fun SignUpScreen(
                 .clickable {
                     onSignUpComplete()
                 }
-                .padding(top = 40.dp, end = 20.dp)
+                .padding(top = 30.dp, end = 20.dp)
                 .align(Alignment.End),
         )
 
@@ -68,7 +70,7 @@ fun SignUpScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 10.dp, start = 16.dp, end = 16.dp),
+                .padding(top = 5.dp, start = 16.dp, end = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
 
@@ -87,7 +89,7 @@ fun SignUpScreen(
             Text(
                 text = "ShopSmart is your one-stop solution for all your shopping needs. Sign up today to enjoy exclusive deals, personalized offers, and more!",
                 fontSize = 14.sp,
-                color = Color(0xFF888888),
+                color = subHeadingColor,
                 textAlign = TextAlign.Center,
                 fontFamily = FontFamily(Font(R.font.lexend_semibold)),
                 modifier = Modifier.padding(horizontal = 16.dp)
@@ -96,7 +98,7 @@ fun SignUpScreen(
         }
 
 
-        Spacer(modifier = Modifier.height(30.dp))
+        Spacer(modifier = Modifier.height(20.dp))
 
         Column(
             modifier = Modifier
@@ -114,7 +116,7 @@ fun SignUpScreen(
                 contentScale = ContentScale.Fit
             )
 
-            Spacer(modifier = Modifier.height(15.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
             OutlinedButton(
                 onClick = {
@@ -122,7 +124,7 @@ fun SignUpScreen(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(50.dp)
+                    .height(45.dp)
                     .padding(start = 16.dp, end = 16.dp),
                 shape = RoundedCornerShape(16.dp),
                 elevation = ButtonDefaults.buttonElevation(3.dp),
@@ -141,7 +143,7 @@ fun SignUpScreen(
                     Text(
                         text = "Continue with Google",
                         fontSize = 15.sp,
-                        color = Color.Black,
+                        color = dark,
                         fontFamily = FontFamily(Font(R.font.lexend_medium))
                     )
                 }
@@ -211,7 +213,7 @@ fun SignUpScreen(
                     Text(
                         text = "Continue with Email",
                         fontSize = 15.sp,
-                        color = Color.Black,
+                        color = dark,
                         fontFamily = FontFamily(Font(R.font.lexend_medium))
                     )
                 }
@@ -224,7 +226,7 @@ fun SignUpScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(bottom = 40.dp)
+                .padding(bottom = 30.dp)
         ) {
 
             Row(

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/Signup.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/Signup.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Info
@@ -29,10 +31,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -47,6 +53,17 @@ fun SignUpScreen(
     onContinueWithEmail: () -> Unit
 ) {
     val context = LocalContext.current
+
+    val annotatedString = buildAnnotatedString {
+        append("By continuing, you agree to our ")
+
+        // Add "Terms of Use" as clickable text
+        pushStringAnnotation(tag = "terms", annotation = "terms_of_use")
+        withStyle(style = SpanStyle(color = Color.Blue, fontSize = 15.sp)) {
+            append("Terms of Use")
+        }
+        pop() // End the clickable part
+    }
 
     Column(
         modifier = Modifier
@@ -231,7 +248,6 @@ fun SignUpScreen(
 
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
                     .padding(start = 16.dp, end = 16.dp),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
@@ -243,31 +259,30 @@ fun SignUpScreen(
                     tint = Color.Cyan,
                     modifier = Modifier
                         .size(24.dp)
-                        .padding(end = 3.dp)
+
                 )
 
-                Text(
-                    text = "By continuing, you agree to our",
-                    fontFamily = FontFamily(Font(R.font.lexend_regular)),
-                    color = Color(0xFF888888),
-                )
-
-                Text(
-                    text = "Terms of Use",
-                    fontFamily = FontFamily(Font(R.font.lexend_regular)),
-                    color = Color.Blue,
-                    fontSize = 15.sp,
+                ClickableText(
+                    text = annotatedString,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(R.font.lexend_regular)),
+                        color = Color(0xFF888888)
+                    ),
                     modifier = Modifier
-                        .clickable {
-                            Toast
-                                .makeText(context, "Terms of Use Clicked", Toast.LENGTH_SHORT)
-                                .show()
-                        }
-                        .padding(start = 5.dp)
-
+                        .padding(16.dp)
+                        .wrapContentWidth(),
+                    onClick = { offset ->
+                        // Check if the user clicked on the "Terms of Use" part
+                        annotatedString.getStringAnnotations(tag = "terms", start = offset, end = offset)
+                            .firstOrNull()?.let {
+                                // Perform the action for "Terms of Use" click
+                                Toast.makeText(context, "Terms of Use Clicked", Toast.LENGTH_SHORT).show()
+                            }
+                    }
                 )
             }
         }
+
 
 
     }

--- a/app/src/main/java/com/yuvrajsinghgmx/shopsmart/ui/theme/Color.kt
+++ b/app/src/main/java/com/yuvrajsinghgmx/shopsmart/ui/theme/Color.kt
@@ -65,3 +65,5 @@ val md_theme_dark_outlineVariant = Color(0xFF404943)
 val md_theme_dark_scrim = Color(0xFF000000)
 
 val textColor= Color(0xFF768689)
+val subHeadingColor=Color(0xFF888888)
+val dark=Color(0xC8000000)


### PR DESCRIPTION
I have added the UI of the "Continue with Email" screen + fixed the text style  of the issue no. #106 
Here it is:-

<img src="https://github.com/user-attachments/assets/0e6ddbc4-4f41-4130-bfe4-e54f8dfe1950" width="411" height="891"/>

@yuvrajsinghgmx please review and merge my pull request.