### PR TITLE
Add bottom navigation with placeholder Search screen and icon color customization

### DIFF
--- a/android-new/.idea/misc.xml
+++ b/android-new/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/android-new/app/build.gradle.kts
+++ b/android-new/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation("androidx.navigation:navigation-compose:2.9.2")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/MainActivity.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/MainActivity.kt
@@ -7,16 +7,14 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ModifierLocalBeyondBoundsLayout
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.rememberNavController
+import com.yuvrajsinghgmx.shopsmart.navigation.BottomNavigationBar
+import com.yuvrajsinghgmx.shopsmart.navigation.NavHost
 import com.yuvrajsinghgmx.shopsmart.ui.theme.ShopSmartTheme
-import org.intellij.lang.annotations.JdkConstants
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,6 +26,15 @@ class MainActivity : ComponentActivity() {
                     Text("This is ShopSmart App.")
                 }
             }
+            val navController = rememberNavController()
+
+            Scaffold (
+                bottomBar = {
+                    BottomNavigationBar(navController = navController)
+                }, content = { padding ->
+                    NavHost(navController = navController, padding = padding)
+                }
+            )
         }
     }
 }

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/BottomNavItem.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/BottomNavItem.kt
@@ -1,0 +1,19 @@
+package com.yuvrajsinghgmx.shopsmart.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class BottomNavItem (
+    val route: String,
+    val icon: ImageVector,
+    val label: String
+){
+    object Home: BottomNavItem("home", Icons.Default.Home, "Home")
+    object Search: BottomNavItem("search", Icons.Default.Search, "Search")
+    object Saved: BottomNavItem("saved", Icons.Default.Favorite, "Saved")
+    object Profile: BottomNavItem("profile", Icons.Default.Person, "Profile")
+}

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/BottomNavigationBar.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/BottomNavigationBar.kt
@@ -1,0 +1,46 @@
+package com.yuvrajsinghgmx.shopsmart.navigation
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.yuvrajsinghgmx.shopsmart.ui.theme.GreenPrimary
+
+@Composable
+fun BottomNavigationBar(navController: NavController) {
+    val items = listOf(
+        BottomNavItem.Home,
+        BottomNavItem.Search,
+        BottomNavItem.Saved,
+        BottomNavItem.Profile
+    )
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    NavigationBar {
+        items.forEach { item ->
+
+            NavigationBarItem(
+                selected = currentRoute == item.route,
+                onClick = {
+                    if (currentRoute != item.route) {
+                        navController.navigate(item.route){
+                            popUpTo(navController.graph.startDestinationId)
+                            launchSingleTop = true
+                        }
+                    }
+                },
+                icon = { Icon(item.icon, contentDescription = item.label) },
+                label = { Text(item.label) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = GreenPrimary,
+                )
+            )
+        }
+    }
+}

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/NavBar.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/navigation/NavBar.kt
@@ -1,2 +1,27 @@
 package com.yuvrajsinghgmx.shopsmart.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.yuvrajsinghgmx.shopsmart.screens.HomeScreen
+import com.yuvrajsinghgmx.shopsmart.screens.SavedProductScreen
+import com.yuvrajsinghgmx.shopsmart.screens.SearchScreen
+import com.yuvrajsinghgmx.shopsmart.screens.UserProfileScreen
+
+@Composable
+fun NavHost(navController: NavHostController, padding: PaddingValues) {
+    NavHost(
+        navController = navController,
+        startDestination = BottomNavItem.Home.route,
+        modifier = Modifier.padding(padding)
+    ) {
+        composable(BottomNavItem.Home.route) { HomeScreen() }
+        composable(BottomNavItem.Search.route) { SearchScreen() }
+        composable(BottomNavItem.Saved.route) { SavedProductScreen() }
+        composable(BottomNavItem.Profile.route) { UserProfileScreen() }
+    }
+}

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/SavedProducts.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/SavedProducts.kt
@@ -1,2 +1,22 @@
 package com.yuvrajsinghgmx.shopsmart.screens
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SavedProductScreen(){
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Saved Products Screen",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/SearchScreen.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/SearchScreen.kt
@@ -9,13 +9,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun HomeScreen() {
+fun SearchScreen() {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = "Home Screen",
+            text = "Search Feature Coming Soon",
             style = MaterialTheme.typography.bodyLarge
         )
     }

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/UserProfileScreen.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/UserProfileScreen.kt
@@ -1,2 +1,22 @@
 package com.yuvrajsinghgmx.shopsmart.screens
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun UserProfileScreen(){
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "User Profile Screen",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}


### PR DESCRIPTION
### Changes Made

- Implemented Bottom Navigation Bar with 4 tabs: Home, Search, Saved, and Profile.
- Used `NavHost` and `BottomNavItem` sealed class to manage navigation.
- Created a `SearchScreen` placeholder with "Coming Soon" message.
- Set the selected icon color to `#4CAF50` (green) for consistency with the app theme.
- Structured code in `navigation/` and `screens/search/` folders for modularity.

### Fixes #286

### Files Added
- `BottomNavigationBar.kt`
- `BottomNavItem.kt`
- `SearchScreen.kt`

### How to Test
1. Run the app.
2. Switch between tabs in the bottom navigation bar.
3. Observe the selected tab turning green.
4. Click on Search → see placeholder screen.

### Ready for Review
Let me know if any UI or logic changes are needed.

This PR is part of my contribution to GSSoC '25
