### PR TITLE
Implement API for Role-Based Shop Creation

### DIFF
--- a/backend-new/ShopSmart/mainapp/permissions.py
+++ b/backend-new/ShopSmart/mainapp/permissions.py
@@ -1,10 +1,24 @@
 from rest_framework import permissions
+
 from django.shortcuts import get_object_or_404
 
-from .models import Shop
+from .models import Shop, User
+
+
+class IsShopOwnerRole(permissions.BasePermission):
+    message = "You must be a Shop Owner to perform this action."
+
+    def has_permission(self, request, view):
+        return request.user and request.user.is_authenticated and request.user.role == User.Role.SHOP_OWNER
+
 
 class IsOwnerOfShop(permissions.BasePermission):
+    message = "You must be the owner of this shop to perform this action."
+
     def has_permission(self, request, view):
         shop_pk = view.kwargs.get('shop_pk')
+        if not shop_pk:
+            return False
+        
         shop = get_object_or_404(Shop, pk=shop_pk)
         return shop.owner == request.user

--- a/backend-new/ShopSmart/mainapp/serializers.py
+++ b/backend-new/ShopSmart/mainapp/serializers.py
@@ -1,7 +1,26 @@
 from rest_framework import serializers
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
-from .models import Product
+from .models import Product, Shop
 
+
+class ShopSerializer(GeoFeatureModelSerializer):
+    owner = serializers.StringRelatedField(read_only=True)
+
+    class Meta:
+        model = Shop
+        geo_field = "location"
+        fields = [
+            'id',
+            'owner',
+            'name',
+            'image',
+            'address',
+            'location',
+            'category',
+            'description',
+            'created_at',
+        ]
 
 
 class ProductSerializer(serializers.ModelSerializer):

--- a/backend-new/ShopSmart/mainapp/urls.py
+++ b/backend-new/ShopSmart/mainapp/urls.py
@@ -1,15 +1,20 @@
 from django.urls import path
 
-from .views import ProductListCreateView
+from .views import ProductListCreateView, ShopListCreateView
 from .firebaseauth_views import FirebaseAuthView,LogoutView
 from rest_framework_simplejwt.views import TokenRefreshView
 
 
 urlpatterns = [
-    path('shops/<int:shop_pk>/products/', ProductListCreateView.as_view(), name='product-list-create'),
-
+    # Auth
     path("auth/firebase/", FirebaseAuthView.as_view(), name="firebase-auth"),
     path("auth/refresh/", TokenRefreshView.as_view(), name="token-refresh"),
     path("auth/logout/", LogoutView.as_view(), name="logout"),
 
+    # Shops
+    path('shops/', ShopListCreateView.as_view(), name='shop-list-create'),
+
+    # Products
+    path('shops/<int:shop_pk>/products/', ProductListCreateView.as_view(), name='product-list-create'),
+    
 ]

--- a/backend-new/ShopSmart/mainapp/views.py
+++ b/backend-new/ShopSmart/mainapp/views.py
@@ -1,23 +1,46 @@
-import os
-import random
+import logging
+
 from dotenv import load_dotenv
 from django.shortcuts import get_object_or_404
-from rest_framework.permissions import AllowAny
+from django.contrib.auth import get_user_model
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
-import logging
+
 from .models import Product, Shop
-from .permissions import IsOwnerOfShop
-from .serializers import  ProductSerializer
+from .permissions import IsOwnerOfShop, IsShopOwnerRole
+from .serializers import ProductSerializer, ShopSerializer
 
 load_dotenv()
+User = get_user_model()
 
 
 logger = logging.getLogger(__name__)
 
+
+class ShopListCreateView(generics.ListCreateAPIView):
+    queryset = Shop.objects.all()
+    serializer_class = ShopSerializer
+    
+    def get_permissions(self):
+        if self.request.method == 'POST':
+            self.permission_classes = [IsAuthenticated, IsShopOwnerRole]
+        else:
+            self.permission_classes = [IsAuthenticated]
+        return super().get_permissions()
+
+    def perform_create(self, serializer):
+        serializer.save(owner=self.request.user)
+
+        
 class ProductListCreateView(generics.ListCreateAPIView):
     serializer_class = ProductSerializer
-    permission_classes = [IsAuthenticated, IsOwnerOfShop]
+
+    def get_permissions(self):
+        if self.request.method == 'POST':
+            self.permission_classes = [IsAuthenticated, IsOwnerOfShop]
+        else:
+            self.permission_classes = [IsAuthenticated]
+        return super().get_permissions()
 
     def get_queryset(self):
         shop_pk = self.kwargs['shop_pk']


### PR DESCRIPTION
Closes: #324

## Description:
- This PR introduces the API endpoints for shop management, leveraging the user role system and geospatial backend. It allows authenticated users with the `SHOP_OWNER` role to create and list shops.
## Key Changes:
- New Shop Endpoint (`/api/shops/`):
      - A `ShopListCreateView` has been created.
      - GET `/shops/`: Allows any authenticated user to retrieve a list of all shops.
      - POST `/shops/`: Is restricted to users with the `SHOP_OWNER` role, allowing them to create a new shop.
- Geospatial Serializer:
       - A `ShopSerializer` that inherits from **rest_framework_gis.serializers.GeoFeatureModelSerializer** has been implemented to handle the location `PointField` in GeoJSON format.
- Role-Based Permissions:
       - A new `IsShopOwnerRole` permission class has been created to restrict access based on `user.role`.
       - The `get_permissions` method is used in the `ShopListCreateView` and `ProductListCreateView` to apply different permissions for read (GET) and write (POST) operations.
