### PR TITLE
Fix: Logout Permissions & Safe Profile Image Handling

### DIFF
--- a/backend-new/ShopSmart/mainapp/firebaseauth_views.py
+++ b/backend-new/ShopSmart/mainapp/firebaseauth_views.py
@@ -5,6 +5,8 @@ from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
 from firebase_admin import auth as firebase_auth
 from firebase_admin.auth import InvalidIdTokenError, ExpiredIdTokenError, RevokedIdTokenError
+from rest_framework.permissions import IsAuthenticated
+
 
 User = get_user_model()
 
@@ -47,7 +49,7 @@ class FirebaseAuthView(APIView):
                     "phone_number": phone,
                     "name": full_name,
                     "role": role,
-                    "profile_pic": user.profile_image.url if user.profile_image else None,
+                    "profile_pic": getattr(user, "profile_image", None).url if getattr(user, "profile_image", None) else None,
                     "is_new_user": is_new_user
                 }
             }, status=status.HTTP_200_OK)
@@ -59,6 +61,8 @@ class FirebaseAuthView(APIView):
 
 
 class LogoutView(APIView):
+    permission_classes = [IsAuthenticated]
+    
     def post(self, request):
         try:
             refresh_token = request.data["refresh"]


### PR DESCRIPTION
@yuvrajsinghgmx solved issue no. #373, Please review.

This PR addresses two critical issues in the authentication system:

**1. Logout Permissions**
* Previously, LogoutView did not require authentication.
* Now, it uses IsAuthenticated permission to ensure only logged-in users can call the logout endpoint.

2. Profile Image Handling

* The FirebaseAuthView response directly accessed user.profile_image.url.
* This could raise an error if profile_image was missing or unset.
* Updated with getattr() to safely handle cases where the field is None or doesn’t exist.

 **Impact**

* Improves security by preventing unauthenticated logout requests.
* Prevents runtime errors when users don’t have a profile image.
* Makes authentication flow more reliable and production-ready.