### PR TITLE
fix(login): add validation for phone number and OTP

### DIFF
--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -8,7 +8,6 @@
           <option name="brand" value="Sony" />
           <option name="codename" value="A402SO" />
           <option name="id" value="A402SO" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Sony" />
           <option name="name" value="Xperia 10" />
           <option name="screenDensity" value="450" />
@@ -20,7 +19,6 @@
           <option name="brand" value="DOCOMO" />
           <option name="codename" value="F01L" />
           <option name="id" value="F01L" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="FUJITSU" />
           <option name="name" value="F-01L" />
           <option name="screenDensity" value="360" />
@@ -32,7 +30,6 @@
           <option name="brand" value="OnePlus" />
           <option name="codename" value="OP535DL1" />
           <option name="id" value="OP535DL1" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="OnePlus" />
           <option name="name" value="CPH2409" />
           <option name="screenDensity" value="401" />
@@ -44,7 +41,17 @@
           <option name="brand" value="OnePlus" />
           <option name="codename" value="OP5552L1" />
           <option name="id" value="OP5552L1" />
-          <option name="labId" value="google" />
+          <option name="manufacturer" value="OnePlus" />
+          <option name="name" value="CPH2415" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2412" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="OnePlus" />
+          <option name="codename" value="OP5552L1" />
+          <option name="id" value="OP5552L1" />
           <option name="manufacturer" value="OnePlus" />
           <option name="name" value="CPH2415" />
           <option name="screenDensity" value="480" />
@@ -56,7 +63,6 @@
           <option name="brand" value="OPPO" />
           <option name="codename" value="OP573DL1" />
           <option name="id" value="OP573DL1" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="OPPO" />
           <option name="name" value="CPH2557" />
           <option name="screenDensity" value="480" />
@@ -68,7 +74,6 @@
           <option name="brand" value="DOCOMO" />
           <option name="codename" value="SH-01L" />
           <option name="id" value="SH-01L" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="SHARP" />
           <option name="name" value="AQUOS sense2 SH-01L" />
           <option name="screenDensity" value="480" />
@@ -80,7 +85,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="a14m" />
           <option name="id" value="a14m" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-A145R" />
           <option name="screenDensity" value="450" />
@@ -92,7 +96,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="a15" />
           <option name="id" value="a15" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="A15" />
           <option name="screenDensity" value="450" />
@@ -104,7 +107,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="a15x" />
           <option name="id" value="a15x" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="A15 5G" />
           <option name="screenDensity" value="450" />
@@ -116,7 +118,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="a16x" />
           <option name="id" value="a16x" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="A16 5G" />
           <option name="screenDensity" value="450" />
@@ -128,7 +129,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="a35x" />
           <option name="id" value="a35x" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="A35" />
           <option name="screenDensity" value="450" />
@@ -140,7 +140,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="akita" />
           <option name="id" value="akita" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 8a" />
           <option name="screenDensity" value="420" />
@@ -152,7 +151,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="akita" />
           <option name="id" value="akita" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 8a" />
           <option name="screenDensity" value="420" />
@@ -164,7 +162,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="arcfox" />
           <option name="id" value="arcfox" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="razr plus 2024" />
           <option name="screenDensity" value="360" />
@@ -176,7 +173,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="austin" />
           <option name="id" value="austin" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="moto g 5G (2022)" />
           <option name="screenDensity" value="280" />
@@ -188,7 +184,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="b0q" />
           <option name="id" value="b0q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S22 Ultra" />
           <option name="screenDensity" value="600" />
@@ -200,7 +195,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="b6q" />
           <option name="id" value="b6q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Flip 6" />
           <option name="screenDensity" value="340" />
@@ -212,7 +206,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="bluejay" />
           <option name="id" value="bluejay" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 6a" />
           <option name="screenDensity" value="420" />
@@ -224,7 +217,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="caiman" />
           <option name="id" value="caiman" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9 Pro" />
           <option name="screenDensity" value="360" />
@@ -236,7 +228,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="caiman" />
           <option name="id" value="caiman" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9 Pro" />
           <option name="screenDensity" value="360" />
@@ -247,9 +238,7 @@
           <option name="api" value="34" />
           <option name="brand" value="google" />
           <option name="codename" value="comet" />
-          <option name="default" value="true" />
           <option name="id" value="comet" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9 Pro Fold" />
           <option name="screenDensity" value="390" />
@@ -260,9 +249,7 @@
           <option name="api" value="35" />
           <option name="brand" value="google" />
           <option name="codename" value="comet" />
-          <option name="default" value="true" />
           <option name="id" value="comet" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9 Pro Fold" />
           <option name="screenDensity" value="390" />
@@ -274,7 +261,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="crownqlteue" />
           <option name="id" value="crownqlteue" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Note9" />
           <option name="screenDensity" value="420" />
@@ -286,7 +272,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="dm2q" />
           <option name="id" value="dm2q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="S23 Plus" />
           <option name="screenDensity" value="450" />
@@ -298,7 +283,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="dm3q" />
           <option name="id" value="dm3q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S23 Ultra" />
           <option name="screenDensity" value="600" />
@@ -310,7 +294,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="dubai" />
           <option name="id" value="dubai" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="edge 30" />
           <option name="screenDensity" value="405" />
@@ -321,9 +304,7 @@
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="e1q" />
-          <option name="default" value="true" />
           <option name="id" value="e1q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S24" />
           <option name="screenDensity" value="480" />
@@ -335,7 +316,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="e3q" />
           <option name="id" value="e3q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S24 Ultra" />
           <option name="screenDensity" value="450" />
@@ -347,7 +327,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="eos" />
           <option name="id" value="eos" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Eos" />
           <option name="screenDensity" value="320" />
@@ -359,7 +338,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="eqe" />
           <option name="id" value="eqe" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="edge 50 pro" />
           <option name="screenDensity" value="450" />
@@ -371,7 +349,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="felix" />
           <option name="id" value="felix" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel Fold" />
           <option name="screenDensity" value="420" />
@@ -383,7 +360,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="felix" />
           <option name="id" value="felix" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel Fold" />
           <option name="screenDensity" value="420" />
@@ -395,7 +371,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="felix_camera" />
           <option name="id" value="felix_camera" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel Fold (Camera-enabled)" />
           <option name="screenDensity" value="420" />
@@ -407,7 +382,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="fogona" />
           <option name="id" value="fogona" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="moto g play - 2024" />
           <option name="screenDensity" value="280" />
@@ -419,7 +393,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="fogos" />
           <option name="id" value="fogos" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="moto g34 5G" />
           <option name="screenDensity" value="280" />
@@ -431,7 +404,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="g0q" />
           <option name="id" value="g0q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-S906U1" />
           <option name="screenDensity" value="450" />
@@ -443,7 +415,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="gta9pwifi" />
           <option name="id" value="gta9pwifi" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-X210" />
           <option name="screenDensity" value="240" />
@@ -455,7 +426,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="gts7lwifi" />
           <option name="id" value="gts7lwifi" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-T870" />
           <option name="screenDensity" value="340" />
@@ -467,7 +437,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="gts7xllite" />
           <option name="id" value="gts7xllite" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-T738U" />
           <option name="screenDensity" value="340" />
@@ -478,9 +447,7 @@
           <option name="api" value="33" />
           <option name="brand" value="samsung" />
           <option name="codename" value="gts8uwifi" />
-          <option name="formFactor" value="Tablet" />
           <option name="id" value="gts8uwifi" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Tab S8 Ultra" />
           <option name="screenDensity" value="320" />
@@ -491,9 +458,7 @@
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="gts8wifi" />
-          <option name="formFactor" value="Tablet" />
           <option name="id" value="gts8wifi" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Tab S8" />
           <option name="screenDensity" value="274" />
@@ -505,7 +470,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="gts9fe" />
           <option name="id" value="gts9fe" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Tab S9 FE 5G" />
           <option name="screenDensity" value="280" />
@@ -517,7 +481,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="gts9wifi" />
           <option name="id" value="gts9wifi" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-X710" />
           <option name="screenDensity" value="340" />
@@ -529,7 +492,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="husky" />
           <option name="id" value="husky" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 8 Pro" />
           <option name="screenDensity" value="390" />
@@ -541,7 +503,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="java" />
           <option name="id" value="java" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="G20" />
           <option name="screenDensity" value="280" />
@@ -553,7 +514,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="komodo" />
           <option name="id" value="komodo" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9 Pro XL" />
           <option name="screenDensity" value="360" />
@@ -565,7 +525,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="komodo" />
           <option name="id" value="komodo" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9 Pro XL" />
           <option name="screenDensity" value="360" />
@@ -577,7 +536,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="lion" />
           <option name="id" value="lion" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="moto g04" />
           <option name="screenDensity" value="280" />
@@ -589,7 +547,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="lynx" />
           <option name="id" value="lynx" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 7a" />
           <option name="screenDensity" value="420" />
@@ -601,7 +558,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="lyriq" />
           <option name="id" value="lyriq" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="edge 40" />
           <option name="screenDensity" value="400" />
@@ -613,7 +569,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="manaus" />
           <option name="id" value="manaus" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="edge 40 neo" />
           <option name="screenDensity" value="400" />
@@ -625,7 +580,6 @@
           <option name="brand" value="motorola" />
           <option name="codename" value="maui" />
           <option name="id" value="maui" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Motorola" />
           <option name="name" value="moto g play - 2023" />
           <option name="screenDensity" value="280" />
@@ -637,7 +591,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="o1q" />
           <option name="id" value="o1q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S21" />
           <option name="screenDensity" value="421" />
@@ -649,7 +602,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="oriole" />
           <option name="id" value="oriole" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 6" />
           <option name="screenDensity" value="420" />
@@ -661,7 +613,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="pa3q" />
           <option name="id" value="pa3q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S25 Ultra" />
           <option name="screenDensity" value="600" />
@@ -673,7 +624,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="panther" />
           <option name="id" value="panther" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 7" />
           <option name="screenDensity" value="420" />
@@ -685,7 +635,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="q5q" />
           <option name="id" value="q5q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Z Fold5" />
           <option name="screenDensity" value="420" />
@@ -697,7 +646,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="q6q" />
           <option name="id" value="q6q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy Z Fold6" />
           <option name="screenDensity" value="420" />
@@ -708,9 +656,7 @@
           <option name="api" value="30" />
           <option name="brand" value="google" />
           <option name="codename" value="r11" />
-          <option name="formFactor" value="Wear OS" />
           <option name="id" value="r11" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel Watch" />
           <option name="screenDensity" value="320" />
@@ -723,7 +669,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="r11q" />
           <option name="id" value="r11q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-S711U" />
           <option name="screenDensity" value="450" />
@@ -735,7 +680,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="redfin" />
           <option name="id" value="redfin" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 5" />
           <option name="screenDensity" value="440" />
@@ -747,7 +691,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="shiba" />
           <option name="id" value="shiba" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 8" />
           <option name="screenDensity" value="420" />
@@ -759,7 +702,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="t2q" />
           <option name="id" value="t2q" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="Galaxy S21 Plus" />
           <option name="screenDensity" value="394" />
@@ -770,9 +712,7 @@
           <option name="api" value="33" />
           <option name="brand" value="google" />
           <option name="codename" value="tangorpro" />
-          <option name="formFactor" value="Tablet" />
           <option name="id" value="tangorpro" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel Tablet" />
           <option name="screenDensity" value="320" />
@@ -784,7 +724,6 @@
           <option name="brand" value="google" />
           <option name="codename" value="tegu" />
           <option name="id" value="tegu" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9a" />
           <option name="screenDensity" value="420" />
@@ -795,9 +734,7 @@
           <option name="api" value="34" />
           <option name="brand" value="google" />
           <option name="codename" value="tokay" />
-          <option name="default" value="true" />
           <option name="id" value="tokay" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9" />
           <option name="screenDensity" value="420" />
@@ -808,9 +745,18 @@
           <option name="api" value="35" />
           <option name="brand" value="google" />
           <option name="codename" value="tokay" />
-          <option name="default" value="true" />
           <option name="id" value="tokay" />
-          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tokay" />
+          <option name="id" value="tokay" />
           <option name="manufacturer" value="Google" />
           <option name="name" value="Pixel 9" />
           <option name="screenDensity" value="420" />
@@ -822,7 +768,6 @@
           <option name="brand" value="samsung" />
           <option name="codename" value="xcover7" />
           <option name="id" value="xcover7" />
-          <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-G556B" />
           <option name="screenDensity" value="450" />

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/LoginScreen.kt
+++ b/android-new/app/src/main/java/com/yuvrajsinghgmx/shopsmart/screens/LoginScreen.kt
@@ -2,40 +2,15 @@ package com.yuvrajsinghgmx.shopsmart.screens
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Security
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.VerticalDivider
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,23 +23,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.yuvrajsinghgmx.shopsmart.R
-import com.yuvrajsinghgmx.shopsmart.modelclass.Shop
-import com.yuvrajsinghgmx.shopsmart.ui.theme.Montserrat
-import com.yuvrajsinghgmx.shopsmart.ui.theme.Roboto
 import com.yuvrajsinghgmx.shopsmart.ui.theme.ShopSmartTypography
-
 
 @Composable
 fun LoginScreen(modifier: Modifier = Modifier) {
 
     var phoneNumber by remember { mutableStateOf("") }
+    var otp by remember { mutableStateOf("") }
+
+    val isPhoneValid = phoneNumber.length == 10 && phoneNumber.all { it.isDigit() }
+    val isOtpValid = otp.length == 6 && otp.all { it.isDigit() }
+    val isFormValid = isPhoneValid && isOtpValid
 
     Surface(
         modifier = modifier.fillMaxSize(),
-        color = Color.White //can be changed for setting up of dark mode
+        color = Color.White
     ) {
         Column(
-            modifier = modifier.fillMaxSize().padding(16.dp),
+            modifier = modifier
+                .fillMaxSize()
+                .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
@@ -76,7 +54,7 @@ fun LoginScreen(modifier: Modifier = Modifier) {
                 contentAlignment = Alignment.Center
             ) {
                 Image(
-                    painter  = painterResource(R.drawable.shield_image),
+                    painter = painterResource(R.drawable.shield_image),
                     contentDescription = "Shield Logo"
                 )
             }
@@ -89,15 +67,17 @@ fun LoginScreen(modifier: Modifier = Modifier) {
             )
             Spacer(Modifier.height(16.dp))
             Text(
-                "Enter your mobile number to continue",
+                "Enter your mobile number and OTP to continue",
                 style = ShopSmartTypography.bodyLarge,
                 fontSize = 20.sp,
             )
             Spacer(Modifier.height(24.dp))
 
-            //phone input row
+            // Phone number input
             Card(
-                modifier = modifier.fillMaxWidth(0.95f).padding(8.dp),
+                modifier = modifier
+                    .fillMaxWidth(0.95f)
+                    .padding(8.dp),
                 colors = CardDefaults.cardColors(
                     containerColor = Color.White
                 ),
@@ -125,23 +105,17 @@ fun LoginScreen(modifier: Modifier = Modifier) {
                             .size(20.dp)
                     )
                     Spacer(Modifier.width(8.dp))
-                    VerticalDivider(
-                        modifier = modifier.size(28.dp),
-                        color = Color.Gray
-                    )
 
-                    //phone number input
                     TextField(
                         value = phoneNumber,
-                        onValueChange = { phoneNumber = it },
+                        onValueChange = { if (it.length <= 10) phoneNumber = it },
                         placeholder = {
                             Text(
                                 text = "Phone number",
                                 color = Color(0xFFBBBBBB)
                             )
                         },
-                        modifier = Modifier
-                            .fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                         colors = OutlinedTextFieldDefaults.colors(
@@ -153,30 +127,101 @@ fun LoginScreen(modifier: Modifier = Modifier) {
                         shape = RoundedCornerShape(8.dp)
                     )
                 }
+                if (!isPhoneValid && phoneNumber.isNotEmpty()) {
+                    Text(
+                        text = "Phone number must be 10 digits",
+                        color = Color.Red,
+                        fontSize = 12.sp,
+                        modifier = Modifier.padding(start = 24.dp, bottom = 4.dp)
+                    )
+                }
                 Spacer(Modifier.height(8.dp))
             }
 
             Spacer(Modifier.height(16.dp))
 
-            //submit button
+            // OTP input
+            Card(
+                modifier = modifier
+                    .fillMaxWidth(0.95f)
+                    .padding(8.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = Color.White
+                ),
+                elevation = CardDefaults.cardElevation(
+                    defaultElevation = 4.dp
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = modifier.padding(horizontal = 24.dp, vertical = 4.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Security,
+                        contentDescription = "OTP",
+                        tint = Color.Blue,
+                        modifier = Modifier
+                            .padding(start = 8.dp)
+                            .size(20.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+
+                    TextField(
+                        value = otp,
+                        onValueChange = { if (it.length <= 6) otp = it },
+                        placeholder = {
+                            Text(
+                                text = "Enter OTP",
+                                color = Color(0xFFBBBBBB)
+                            )
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = Color.Transparent,
+                            unfocusedBorderColor = Color.Transparent,
+                            focusedTextColor = Color(0xFF333333),
+                            unfocusedTextColor = Color(0xFF333333)
+                        ),
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                }
+                if (!isOtpValid && otp.isNotEmpty()) {
+                    Text(
+                        text = "OTP must be 6 digits",
+                        color = Color.Red,
+                        fontSize = 12.sp,
+                        modifier = Modifier.padding(start = 24.dp, bottom = 4.dp)
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Submit button
             Button(
-                onClick = { /* Otp sending logic */ },
+                onClick = { /* Handle login */ },
+                enabled = isFormValid,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
                     .height(56.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = Color(0xFF4CAF50),
+                    containerColor = if (isFormValid) Color(0xFF4CAF50) else Color.Gray,
                     contentColor = Color.White
                 ),
                 shape = RoundedCornerShape(12.dp)
             ) {
                 Text(
-                    text = "Send OTP",
+                    text = "Login",
                     fontSize = 16.sp,
                     style = ShopSmartTypography.headlineLarge
                 )
             }
+
             Spacer(Modifier.height(24.dp))
             Text(
                 text = "By continuing, you agree to our Terms & Privacy Policy",
@@ -187,7 +232,6 @@ fun LoginScreen(modifier: Modifier = Modifier) {
                 modifier = Modifier.padding(horizontal = 32.dp),
                 lineHeight = 1.5.em
             )
-
             Spacer(modifier = Modifier.height(40.dp))
         }
     }


### PR DESCRIPTION
## Description
This PR adds validation logic to the **Login Screen**.

- Phone number is now restricted to **10 digits only**.
- OTP is restricted to **6 digits only**.
- The "Send OTP" button remains disabled until both inputs are valid.

## Related Issue
Fixes #406

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] I am a GSSoC '25 participant